### PR TITLE
Fixing uneven spacing between image and title on some screen widths

### DIFF
--- a/frontend/src/components/home/Peek.js
+++ b/frontend/src/components/home/Peek.js
@@ -43,7 +43,7 @@ export default function Peek() {
           {posts.map((post) => (
             <article
               key={post.id}
-              className="flex flex-col items-start justify-between"
+              className="flex flex-col items-start"
             >
               <div className="relative w-full flex items-center">
                 <div className="p-6 aspect-[16/9] w-full rounded-2xl bg-primary/5 sm:aspect-[2/1] lg:aspect-[3/2]">


### PR DESCRIPTION
little thing I noticed with weird spacing
<img width="1098" alt="image" src="https://github.com/beckybooboo/loamy_wlm/assets/11167066/432f4f0f-9264-477d-b309-06d29e2dc0fa">
